### PR TITLE
Disable webpacks eval code

### DIFF
--- a/src/utils/global.js
+++ b/src/utils/global.js
@@ -1,0 +1,1 @@
+module.exports = window

--- a/src/webpack-config.js
+++ b/src/webpack-config.js
@@ -199,6 +199,18 @@ module.exports = function webpackConfig ({
     }))
   }
 
+  // Disable webpacks usage of eval by disabling nodes global
+  // @url https://github.com/webpack/webpack/blob/master/buildin/global.js
+  config.node = {
+    global: false
+  }
+  // In order to still be able to use global we use window instead
+  config.plugins.push(
+    new webpack.ProvidePlugin({
+      global: require.resolve('./utils/global.js')
+    })
+  )
+
   config.plugins.push(new WebpackBar())
 
   return config


### PR DESCRIPTION
Using eval in chrome extensions is not recommended, since it opens the door for many security issues.

Webpack uses eval, in order to provide a `global` object. This feature is build in a way, that uses `eval` under the hood. ([Souce](https://github.com/webpack/webpack/blob/master/buildin/global.js))

Since webextensions always run in a web context, we don't need this functionality.
Instead we can link `global` with `window`. This is why this PR doesn't introduce a breaking change.

