### PR TITLE
 [FIX] Premature exit of build process; Fixes #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,25 @@ Allows you to define vendor specific manifest keys.
 ```
 "name": "my-extension"
 "__chrome__key": "yourchromekey"
+"__chrome|opera__key2: "yourblinkkey"
 ```
 If the vendor is `chrome` it compiles to:
 ```
 "name": "my-extension"
 "key": "yourchromekey"
+"key2": "yourblinkkey"
+```
+If the vendor is `opera` it compiles to:
+```
+"name": "my-extension"
+"key2": "yourblinkkey"
 ```
 else it compiles to:
 
 ```
 "name": "my-extension"
 ```
+
 ## polyfill
   
 The [webextension standard](https://developer.mozilla.org/de/Add-ons/WebExtensions) is currently only supported by firefox and edge. This toolbox adds the necessary polyfills for chrome and opera. 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All javascript files located at the root of your `./app` or `./app/scripts` dire
 
 ## Customizing webpack config
 
-In order to extend our usage of `webpack`, you can define a function that extends its config via `webextension-toolbox.js`.
+In order to extend our usage of `webpack`, you can define a function that extends its config via `webextension-toolbox-config.js`.
 
 ```js
 // This file is not going through babel transformation.

--- a/src/utils/get-config-file-config.js
+++ b/src/utils/get-config-file-config.js
@@ -1,7 +1,7 @@
 const findUp = require('find-up')
 
 module.exports = function getConfig () {
-  const path = findUp.sync('webextension-toolbox.js')
+  const path = findUp.sync('webextension-toolbox-config.js')
 
   let config = {}
 


### PR DESCRIPTION
I did some depper digging into the code and it appears that nothing gets executed of the toolbox when the `**webextension-toolbox.js**` exists. Not even `logBanner()` defined in the commander programs in `bin/**webextension-toolbox.js**`

Here I noticed that both files are named the same. Thinking that this might be the cause of the problem because the `find-up` module looks for this filename to access the config file, I tried giving the config a `-config` postfix, which made it work as intended even under windows cmd/powershell.

But why this issue actually arose is still a bit of a mystery because the `find-up` module actually can't be responsible, given the module isn't even required and it's function executed, because the build process exits literally at the beginning of the program. It's more likely the fault lies somewhere in the `commander` used for processing the arguments and starting the tool, indicated by my observation that not event he first command in the program-chain (`logBanner()`) gets executed.

I also updated the README for not only this issue, but also to reflect the ability for multi-key vendors added to the `webextension-toolbox-plugin v0.1.1`.